### PR TITLE
pass id instead of hero or villain object when firing delete mutations

### DIFF
--- a/xx-final/vue-heroes/src/store/index.js
+++ b/xx-final/vue-heroes/src/store/index.js
@@ -32,8 +32,8 @@ const mutations = {
   [GET_HEROES](state, heroes) {
     state.heroes = heroes;
   },
-  [DELETE_HERO](state, hero) {
-    state.heroes = [...state.heroes.filter(p => p.id !== hero.id)];
+  [DELETE_HERO](state, heroId) {
+    state.heroes = [...state.heroes.filter(p => p.id !== heroId)];
   },
   [ADD_VILLAIN](state, villain) {
     state.villains.unshift(villain); // mutable addition
@@ -46,8 +46,8 @@ const mutations = {
   [GET_VILLAINS](state, villains) {
     state.villains = villains;
   },
-  [DELETE_VILLAIN](state, villain) {
-    state.villains = [...state.villains.filter(p => p.id !== villain.id)];
+  [DELETE_VILLAIN](state, villainId) {
+    state.villains = [...state.villains.filter(p => p.id !== villainId)];
   },
 };
 


### PR DESCRIPTION
Hi @johnpapa ,

In the final version of the app, the hero and villain objects are passed when firing the delete mutations instead of the id. You fixed this already for the end folder of part 9 of the course, but not here, so I made a pull request for it.

Cheers,
Mathias